### PR TITLE
Improve ADB setup docs and path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ pip install -r requirements.txt
 ```
 
 3. Install ADB (Android Debug Bridge). You can obtain it from the Android SDK Platform Tools.
-4. Ensure your Android emulator is running and has USB debugging enabled.
+4. If `adb.exe` is not installed at `C:\platform-tools\adb.exe`, edit `filepath/file_relative_paths.py` and update `ADB_EXE_PATH` to the full path of your `adb.exe`.
+5. Ensure your Android emulator is running and has USB debugging enabled.
 
 ## Usage
 

--- a/adb.py
+++ b/adb.py
@@ -4,6 +4,7 @@ from utils import build_command
 from filepath.file_relative_paths import FilePaths
 import subprocess
 import traceback
+import os
 
 
 bridge = None
@@ -38,6 +39,10 @@ class Adb:
 
 
 def enable_adb(host="127.0.0.1", port=5037):
+    adb_path = resource_path(FilePaths.ADB_EXE_PATH.value)
+    if not os.path.isfile(adb_path):
+        raise RuntimeError(f"ADB executable not found: {adb_path}")
+
     adb = None
     try:
         adb = Adb(host, port)
@@ -53,10 +58,8 @@ def enable_adb(host="127.0.0.1", port=5037):
 
     except RuntimeError as err:
 
-        adb_path = resource_path(FilePaths.ADB_EXE_PATH.value)
-
         ret = subprocess.run(
-            build_command(adb_path, "-P", str(port), "kill-server", host),
+            build_command(adb_path, "-P", str(port), "kill-server"),
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- explain how to set the path to `adb.exe`
- validate `ADB_EXE_PATH` before running ADB commands
- stop including host when calling `adb kill-server`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68597044b82c832db29687eeee6daaaf